### PR TITLE
Update issue templates to make creating issues easier

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-## Bug report
-
-Provide a brief summary of your issue **AND** if reporting a build issue include the version/build number.
-
-## Feature request
-
-Provide a brief summary of the new feature required.
-
-**Please note by far the quickest way to get a new feature is to file a Pull Request.**

--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,20 @@
+---
+name: "Bug Report"
+about: "You found something that is not working. Report it so that it can be fixed. 👷‍"
+title: "Fix: "
+labels: "type : bug"
+---
+
+## Issue
+
+Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+ 
+## Expected
+
+Describe what should be the correct behaviour.
+ 
+## Steps to reproduce
+
+1. 
+2. 
+3.

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,14 @@
+---
+name: "Feature"
+about: "Open a feature issue to add new functionalities."
+title: "As a user, I can "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the big picture of the feature and why it's needed. 
+
+## Acceptance Criteria
+
+Describe the required outputs that is needed to close this ticket.


### PR DESCRIPTION
## What happened

Update GitHub workflow to have different types of issue templates to choose from
 
## Insight

Taken inspiration from our [Compass Repo](https://github.com/nimblehq/compass/tree/development/.github/ISSUE_TEMPLATE)
 
## Proof Of Work

Similar to this:

![Screen Shot 2021-01-11 at 2 36 06 PM](https://user-images.githubusercontent.com/34730459/104155727-5d87dd00-541a-11eb-9be7-5f7f5d1e4308.png)

