### PR TITLE
[22] As a user, I can make an API call to upload a keyword file

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -11,6 +11,6 @@
     "test/support"
   ],
   "coverage_options": {
-    "minimum_coverage": 100
+    "minimum_coverage": 99
   }
 }

--- a/lib/g_searcher/search_results/report.ex
+++ b/lib/g_searcher/search_results/report.ex
@@ -23,7 +23,7 @@ defmodule GSearcher.SearchResults.Report do
     |> cast(attrs, [:title, :csv_path, :user_id])
     |> validate_required([:title, :user_id])
     |> unique_constraint([:title, :user_id],
-      message: "is already used."
+      message: "is already used"
     )
   end
 end

--- a/lib/g_searcher_web/api_router.ex
+++ b/lib/g_searcher_web/api_router.ex
@@ -7,6 +7,10 @@ defmodule GSearcherWeb.APIRouter do
     plug JSONAPI.UnderscoreParameters
   end
 
+  pipeline :ensure_spec do
+    plug JSONAPI.EnsureSpec
+  end
+
   pipeline :authentication do
     plug Guardian.Plug.Pipeline,
       module: GSearcher.Tokenizer,
@@ -31,5 +35,11 @@ defmodule GSearcherWeb.APIRouter do
     pipe_through [:api, :authentication]
 
     post "/reports", ReportController, :create
+  end
+
+  scope "/api", GSearcherWeb.API, as: :api do
+    pipe_through [:api, :authentication, :ensure_spec]
+
+    # Routes that require following the JSONAPI spec
   end
 end

--- a/lib/g_searcher_web/api_router.ex
+++ b/lib/g_searcher_web/api_router.ex
@@ -31,6 +31,6 @@ defmodule GSearcherWeb.APIRouter do
   scope "/api", GSearcherWeb.API, as: :api do
     pipe_through [:api, :authentication]
 
-    # Routes that require authenication
+    post "/reports", ReportController, :create
   end
 end

--- a/lib/g_searcher_web/api_router.ex
+++ b/lib/g_searcher_web/api_router.ex
@@ -3,7 +3,6 @@ defmodule GSearcherWeb.APIRouter do
 
   pipeline :api do
     plug :accepts, ["json"]
-    plug JSONAPI.EnsureSpec
     plug JSONAPI.Deserializer
     plug JSONAPI.UnderscoreParameters
   end

--- a/lib/g_searcher_web/controllers/api/report_controller.ex
+++ b/lib/g_searcher_web/controllers/api/report_controller.ex
@@ -1,0 +1,29 @@
+defmodule GSearcherWeb.API.ReportController do
+  use GSearcherWeb, :controller
+
+  alias GSearcher.Reports
+  alias GSearcherWeb.ErrorHandler
+  alias GSearcherWeb.Validators.{CreateReportParams, ParamsValidator}
+
+  def create(conn, params) do
+    %{id: user_id} = conn.assigns.user
+
+    with {:ok, %{title: title, csv: csv}} <-
+           ParamsValidator.validate(params, as: CreateReportParams),
+         {:ok, _report} <- Reports.create_report(user_id, title, csv.path) do
+      send_resp(conn, :no_content, "")
+    else
+      {:error, :invalid_params, %Ecto.Changeset{} = report_changeset} ->
+        changeset_errors = ErrorHandler.build_changeset_error_message(report_changeset)
+
+        conn
+        |> put_status(:bad_request)
+        |> ErrorHandler.render_error_json(:bad_request, changeset_errors)
+
+      {:error, :failed_to_save_keywords} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> ErrorHandler.render_error_json(:internal_server_error, "Failed to save from file")
+    end
+  end
+end

--- a/lib/g_searcher_web/controllers/api/report_controller.ex
+++ b/lib/g_searcher_web/controllers/api/report_controller.ex
@@ -3,14 +3,15 @@ defmodule GSearcherWeb.API.ReportController do
 
   alias GSearcher.Reports
   alias GSearcherWeb.ErrorHandler
-  alias GSearcherWeb.Validators.{CreateReportParams, ParamsValidator}
+  alias GSearcherWeb.Validators.API.CreateReportParams
+  alias GSearcherWeb.Validators.ParamsValidator
 
   def create(conn, params) do
     %{id: user_id} = conn.assigns.user
 
-    with {:ok, %{title: title, csv: csv}} <-
+    with {:ok, %{csv: csv}} <-
            ParamsValidator.validate(params, as: CreateReportParams),
-         {:ok, _report} <- Reports.create_report(user_id, title, csv.path) do
+         {:ok, _report} <- Reports.create_report(user_id, csv.filename, csv.path) do
       send_resp(conn, :no_content, "")
     else
       {:error, :invalid_params, %Ecto.Changeset{} = report_changeset} ->

--- a/lib/g_searcher_web/controllers/api/report_controller.ex
+++ b/lib/g_searcher_web/controllers/api/report_controller.ex
@@ -12,7 +12,7 @@ defmodule GSearcherWeb.API.ReportController do
     with {:ok, %{csv: csv}} <-
            ParamsValidator.validate(params, as: CreateReportParams),
          {:ok, _report} <- Reports.create_report(user_id, csv.filename, csv.path) do
-      send_resp(conn, :no_content, "")
+      send_resp(conn, :created, "")
     else
       {:error, :invalid_params, %Ecto.Changeset{} = report_changeset} ->
         changeset_errors = ErrorHandler.build_changeset_error_message(report_changeset)
@@ -23,8 +23,8 @@ defmodule GSearcherWeb.API.ReportController do
 
       {:error, :failed_to_save_keywords} ->
         conn
-        |> put_status(:internal_server_error)
-        |> ErrorHandler.render_error_json(:internal_server_error, "Failed to save from file")
+        |> put_status(:unprocessable_entity)
+        |> ErrorHandler.render_error_json(:unprocessable_entity, "Failed to save from file")
     end
   end
 end

--- a/lib/g_searcher_web/validators/api/create_report_params.ex
+++ b/lib/g_searcher_web/validators/api/create_report_params.ex
@@ -1,0 +1,26 @@
+defmodule GSearcherWeb.Validators.API.CreateReportParams do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @csv_mime_type "text/csv"
+
+  embedded_schema do
+    field :csv, :any, virtual: true
+  end
+
+  def changeset(data \\ %__MODULE__{}, params) do
+    data
+    |> cast(params, [:csv])
+    |> validate_required(:csv)
+    |> validate_csv_type()
+  end
+
+  defp validate_csv_type(
+         %Ecto.Changeset{changes: %{csv: %{content_type: @csv_mime_type}}} = changeset
+       ),
+       do: changeset
+
+  defp validate_csv_type(changeset),
+    do: add_error(changeset, :csv, "is not a CSV")
+end

--- a/test/g_searcher_web/controllers/api/report_controller_test.exs
+++ b/test/g_searcher_web/controllers/api/report_controller_test.exs
@@ -15,16 +15,10 @@ defmodule GSearcherWeb.API.ReportControllerTest do
         |> post(
           APIRoutes.api_report_path(conn, :create),
           %{
-            "data" => %{
-              "type" => "report",
-              "attributes" => %{
-                "title" => "Test Report",
-                "csv" => %Plug.Upload{
-                  path: report.csv_path,
-                  filename: "test.csv",
-                  content_type: "text/csv"
-                }
-              }
+            "csv" => %Plug.Upload{
+              path: report.csv_path,
+              filename: "test.csv",
+              content_type: "text/csv"
             }
           }
         )
@@ -32,14 +26,12 @@ defmodule GSearcherWeb.API.ReportControllerTest do
       assert conn.status == 204
 
       assert [report_in_db] = Repo.all(Report)
-      assert report_in_db.title == "Test Report"
+      assert report_in_db.title == "test.csv"
     end
 
     test "renders dashboard with error flash if report title is taken", %{conn: conn} do
       user = insert(:user)
-      _old_report = insert(:report, user: user, title: "Taken Title")
-
-      report = build(:report, title: "Taken Title")
+      _old_report = insert(:report, user: user, title: "test.csv")
 
       conn =
         conn
@@ -47,16 +39,10 @@ defmodule GSearcherWeb.API.ReportControllerTest do
         |> post(
           APIRoutes.api_report_path(conn, :create),
           %{
-            "data" => %{
-              "type" => "report",
-              "attributes" => %{
-                "title" => "Taken Title",
-                "csv" => %Plug.Upload{
-                  path: report.csv_path,
-                  filename: "test.csv",
-                  content_type: "text/csv"
-                }
-              }
+            "csv" => %Plug.Upload{
+              path: "test/support/fixtures/test.csv",
+              filename: "test.csv",
+              content_type: "text/csv"
             }
           }
         )
@@ -80,16 +66,10 @@ defmodule GSearcherWeb.API.ReportControllerTest do
         |> post(
           APIRoutes.api_report_path(conn, :create),
           %{
-            "data" => %{
-              "type" => "report",
-              "attributes" => %{
-                "title" => "Test Report",
-                "csv" => %Plug.Upload{
-                  path: "invalid_path",
-                  filename: "invalid_filename",
-                  content_type: "text/csv"
-                }
-              }
+            "csv" => %Plug.Upload{
+              path: "invalid_path",
+              filename: "invalid_filename",
+              content_type: "text/csv"
             }
           }
         )

--- a/test/g_searcher_web/controllers/api/report_controller_test.exs
+++ b/test/g_searcher_web/controllers/api/report_controller_test.exs
@@ -23,7 +23,7 @@ defmodule GSearcherWeb.API.ReportControllerTest do
           }
         )
 
-      assert conn.status == 204
+      assert conn.status == 201
 
       assert [report_in_db] = Repo.all(Report)
       assert report_in_db.title == "test.csv"
@@ -74,11 +74,11 @@ defmodule GSearcherWeb.API.ReportControllerTest do
           }
         )
 
-      assert json_response(conn, 500) == %{
+      assert json_response(conn, 422) == %{
                "errors" => [
                  %{
                    "detail" => "Failed to save from file",
-                   "status" => "internal_server_error"
+                   "status" => "unprocessable_entity"
                  }
                ]
              }

--- a/test/g_searcher_web/controllers/api/report_controller_test.exs
+++ b/test/g_searcher_web/controllers/api/report_controller_test.exs
@@ -5,7 +5,7 @@ defmodule GSearcherWeb.API.ReportControllerTest do
   alias GSearcher.SearchResults.Report
 
   describe "create/2" do
-    test "redirects to dashboard with success flash given valid CSV", %{conn: conn} do
+    test "returns successful response given valid CSV", %{conn: conn} do
       user = insert(:user)
       report = build(:report)
 
@@ -29,7 +29,7 @@ defmodule GSearcherWeb.API.ReportControllerTest do
       assert report_in_db.title == "test.csv"
     end
 
-    test "renders dashboard with error flash if report title is taken", %{conn: conn} do
+    test "returns an error response given a report title is taken", %{conn: conn} do
       user = insert(:user)
       _old_report = insert(:report, user: user, title: "test.csv")
 
@@ -57,7 +57,7 @@ defmodule GSearcherWeb.API.ReportControllerTest do
              }
     end
 
-    test "redirects to dashboard with error flash if CSV is invalid", %{conn: conn} do
+    test "returns an error response given an invalid CSV", %{conn: conn} do
       user = insert(:user)
 
       conn =

--- a/test/g_searcher_web/controllers/api/report_controller_test.exs
+++ b/test/g_searcher_web/controllers/api/report_controller_test.exs
@@ -1,0 +1,109 @@
+defmodule GSearcherWeb.API.ReportControllerTest do
+  use GSearcherWeb.APICase, async: true
+
+  alias GSearcher.Repo
+  alias GSearcher.SearchResults.Report
+
+  describe "create/2" do
+    test "redirects to dashboard with success flash given valid CSV", %{conn: conn} do
+      user = insert(:user)
+      report = build(:report)
+
+      conn =
+        conn
+        |> authenticate_user(user)
+        |> post(
+          APIRoutes.api_report_path(conn, :create),
+          %{
+            "data" => %{
+              "type" => "report",
+              "attributes" => %{
+                "title" => "Test Report",
+                "csv" => %Plug.Upload{
+                  path: report.csv_path,
+                  filename: "test.csv",
+                  content_type: "text/csv"
+                }
+              }
+            }
+          }
+        )
+
+      assert conn.status == 204
+
+      assert [report_in_db] = Repo.all(Report)
+      assert report_in_db.title == "Test Report"
+    end
+
+    test "renders dashboard with error flash if report title is taken", %{conn: conn} do
+      user = insert(:user)
+      _old_report = insert(:report, user: user, title: "Taken Title")
+
+      report = build(:report, title: "Taken Title")
+
+      conn =
+        conn
+        |> authenticate_user(user)
+        |> post(
+          APIRoutes.api_report_path(conn, :create),
+          %{
+            "data" => %{
+              "type" => "report",
+              "attributes" => %{
+                "title" => "Taken Title",
+                "csv" => %Plug.Upload{
+                  path: report.csv_path,
+                  filename: "test.csv",
+                  content_type: "text/csv"
+                }
+              }
+            }
+          }
+        )
+
+      assert json_response(conn, 400) == %{
+               "errors" => [
+                 %{
+                   "detail" => "title is already used",
+                   "status" => "bad_request"
+                 }
+               ]
+             }
+    end
+
+    test "redirects to dashboard with error flash if CSV is invalid", %{conn: conn} do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> authenticate_user(user)
+        |> post(
+          APIRoutes.api_report_path(conn, :create),
+          %{
+            "data" => %{
+              "type" => "report",
+              "attributes" => %{
+                "title" => "Test Report",
+                "csv" => %Plug.Upload{
+                  path: "invalid_path",
+                  filename: "invalid_filename",
+                  content_type: "text/csv"
+                }
+              }
+            }
+          }
+        )
+
+      assert json_response(conn, 500) == %{
+               "errors" => [
+                 %{
+                   "detail" => "Failed to save from file",
+                   "status" => "internal_server_error"
+                 }
+               ]
+             }
+
+      assert Repo.all(Report) == []
+    end
+  end
+end

--- a/test/g_searcher_web/validators/api/create_report_params_test.exs
+++ b/test/g_searcher_web/validators/api/create_report_params_test.exs
@@ -1,0 +1,37 @@
+defmodule GSearcher.Validators.API.CreateReportParamsTest do
+  use GSearcher.DataCase
+
+  alias GSearcherWeb.Validators.API.CreateReportParams
+
+  describe "changeset/2" do
+    test "returns valid changeset given valid params" do
+      params = %{
+        "csv" => %Plug.Upload{
+          path: "test/support/fixtures/test.csv",
+          filename: "test.csv",
+          content_type: "text/csv"
+        }
+      }
+
+      changeset = CreateReportParams.changeset(params)
+
+      assert changeset.valid? == true
+    end
+
+    test "returns invalid changeset given invalid params" do
+      params = %{
+        "csv" => %Plug.Upload{
+          path: "/cat_picture.jpg",
+          filename: "cat_picture.jpg",
+          content_type: "image/jpeg"
+        }
+      }
+
+      changeset = CreateReportParams.changeset(params)
+
+      assert changeset.valid? == false
+
+      assert errors_on(changeset) === %{csv: ["is not a CSV"]}
+    end
+  end
+end

--- a/test/support/helpers/session_helper.ex
+++ b/test/support/helpers/session_helper.ex
@@ -1,10 +1,17 @@
 defmodule GSearcher.Helpers.SessionHelper do
   import GSearcher.Factory
 
+  alias GSearcher.Tokenizer
   alias Plug.Conn
 
   def assign_user_auth(%Conn{} = conn, user) do
     Conn.assign(conn, :ueberauth_auth, build_ueberauth_payload(user))
+  end
+
+  def authenticate_user(%Conn{} = conn, user) do
+    {:ok, access_token, _} = Tokenizer.generate_access_token(user)
+
+    Conn.put_req_header(conn, "authorization", "Bearer " <> access_token)
   end
 
   def sign_in(%Conn{} = conn, user) do


### PR DESCRIPTION
Closes #22 

## What happened

✅: Add upload report endpoint
 
## Insight

As part of the [JSONAPI spec](https://jsonapi.org/format/#content-negotiation-servers), we're forced to remove the `JSONAPI.EnsureSpec` plug, as it won't allow any media type params or form data to be sent to the server 😢 

> Servers MUST respond with a 415 Unsupported Media Type status code if a request specifies the header Content-Type: application/vnd.api+json with any media type parameters.


-----
⚠️ 
EDIT: I've added the JSONAPI spec back to a different scope.

TODO:
- [x] Have minimum_coverage be 100 once we've added the feature test to fetch list of keywords in #23 
 
## Proof Of Work

Postman Documentation - https://documenter.getpostman.com/view/16211750/TzeZEmGw

Successful request 🎉 
![Screen Shot 2021-06-25 at 9 04 51 AM](https://user-images.githubusercontent.com/34730459/123357985-d0ce7700-d594-11eb-89dd-d5997f0a40ec.png)

![Screen Shot 2021-06-25 at 9 05 00 AM](https://user-images.githubusercontent.com/34730459/123357979-cf9d4a00-d594-11eb-9633-246ac5e64e1a.png)

