### PR TITLE
[24] As a user, I can make an API call to search for keywords across my reports

### DIFF
--- a/lib/g_searcher_web/controllers/api/search_result_controller.ex
+++ b/lib/g_searcher_web/controllers/api/search_result_controller.ex
@@ -5,7 +5,17 @@ defmodule GSearcherWeb.API.SearchResultController do
   alias GSearcherWeb.ErrorHandler
   alias GSearcherWeb.Validators.{ParamsValidator, SearchResultParams}
 
-  def index(conn, params) when is_map(params) do
+  def index(conn, params) when params == %{} do
+    %{id: user_id} = conn.assigns.user
+
+    search_results = SearchResults.list_search_results_by_user_id(user_id)
+
+    conn
+    |> put_status(:ok)
+    |> render("index.json", %{search_results: search_results})
+  end
+
+  def index(conn, params) do
     %{id: user_id} = conn.assigns.user
 
     with {:ok, validated_params} <-
@@ -20,16 +30,6 @@ defmodule GSearcherWeb.API.SearchResultController do
         |> put_status(:bad_request)
         |> ErrorHandler.render_error_json(:bad_request, changeset_errors)
     end
-  end
-
-  def index(conn, _params) do
-    %{id: user_id} = conn.assigns.user
-
-    search_results = SearchResults.list_search_results_by_user_id(user_id)
-
-    conn
-    |> put_status(:ok)
-    |> render("index.json", %{search_results: search_results})
   end
 
   def show(conn, %{"id" => search_result_id}) do

--- a/test/g_searcher_web/controllers/api/search_result_controller_test.exs
+++ b/test/g_searcher_web/controllers/api/search_result_controller_test.exs
@@ -94,7 +94,7 @@ defmodule GSearcherWeb.API.SearchResultControllerTest do
       assert json_response(conn, 200) == %{"data" => []}
     end
 
-    test "renders search results belonging to user given invalid params", %{conn: conn} do
+    test "returns a 400 error response belonging to user given invalid params", %{conn: conn} do
       user = insert(:user)
       report = insert(:report, user: user)
 

--- a/test/g_searcher_web/controllers/api/search_result_controller_test.exs
+++ b/test/g_searcher_web/controllers/api/search_result_controller_test.exs
@@ -2,7 +2,7 @@ defmodule GSearcherWeb.API.SearchResultControllerTest do
   use GSearcherWeb.APICase, async: true
 
   describe "index/2" do
-    test "returns search results belonging to the user", %{conn: conn} do
+    test "returns search results belonging to the user given no params", %{conn: conn} do
       user = insert(:user)
       report = insert(:report, user: user)
 
@@ -50,6 +50,39 @@ defmodule GSearcherWeb.API.SearchResultControllerTest do
              }
     end
 
+    test "returns search results belonging to user given valid params", %{conn: conn} do
+      user = insert(:user)
+      report = insert(:report, user: user)
+
+      search_result =
+        insert(:search_result, total_number_of_results: 1_000_000, search_term: "Boba Tea")
+
+      _report_search_result =
+        insert(:report_search_result, report: report, search_result: search_result)
+
+      conn =
+        conn
+        |> authenticate_user(user)
+        |> get(APIRoutes.api_search_result_path(conn, :index), %{query: "Tea"})
+
+      assert json_response(conn, 200) == %{
+               "data" => [
+                 %{
+                   "type" => "search_result",
+                   "id" => search_result.id,
+                   "attributes" => %{
+                     "keyword" => search_result.search_term,
+                     "status" => "Completed",
+                     "top_advertiser_count" => search_result.number_of_top_advertisers,
+                     "regular_advertiser_count" => search_result.number_of_regular_advertisers,
+                     "page_result_count" => search_result.number_of_results_on_page,
+                     "total_result_count" => "1 Million"
+                   }
+                 }
+               ]
+             }
+    end
+
     test "returns no search results given the user has NO search results", %{conn: conn} do
       user = insert(:user)
 
@@ -59,6 +92,34 @@ defmodule GSearcherWeb.API.SearchResultControllerTest do
         |> get(APIRoutes.api_search_result_path(conn, :index))
 
       assert json_response(conn, 200) == %{"data" => []}
+    end
+
+    test "renders search results belonging to user given invalid params", %{conn: conn} do
+      user = insert(:user)
+      report = insert(:report, user: user)
+
+      search_result =
+        insert(:search_result, total_number_of_results: 1_000_000, search_term: "Boba Tea")
+
+      _report_search_result =
+        insert(:report_search_result, report: report, search_result: search_result)
+
+      conn =
+        conn
+        |> authenticate_user(user)
+        |> get(APIRoutes.api_search_result_path(conn, :index), %{
+          query: "Tea",
+          top_ads: "Boba Tea"
+        })
+
+      assert json_response(conn, 400) == %{
+               "errors" => [
+                 %{
+                   "detail" => "top_ads operation should only be '<, >, ='",
+                   "status" => "bad_request"
+                 }
+               ]
+             }
     end
   end
 


### PR DESCRIPTION
Closes #24 

## What happened

✅: Search through user keywords using filter params
 
## Insight

Just reusing implementation from #58, without the `SearchHelper` module to parse the params.
 
## Proof Of Work

Postman Documentation - https://documenter.getpostman.com/view/16211750/TzeZEmGw

#### Success response
![Screen Shot 2021-07-04 at 10 36 45 PM](https://user-images.githubusercontent.com/34730459/124390990-7d88c100-dd18-11eb-91fc-41a93144c68f.png)

#### Using filter
![Screen Shot 2021-07-04 at 10 36 59 PM](https://user-images.githubusercontent.com/34730459/124390998-82e60b80-dd18-11eb-85c2-79ec05664f6d.png)

#### Error response
![Screen Shot 2021-07-04 at 10 37 37 PM](https://user-images.githubusercontent.com/34730459/124391003-87aabf80-dd18-11eb-8492-78445429f64a.png)
