### PR TITLE
[47] Fix: Incorrect value of results on page in Report Show Page

### DIFF
--- a/lib/g_searcher/search_results/search_result_parser.ex
+++ b/lib/g_searcher/search_results/search_result_parser.ex
@@ -71,7 +71,9 @@ defmodule GSearcher.SearchResults.SearchResultParser do
     search_result_urls =
       html_tree
       |> build_result_params(@search_results)
-      |> Enum.reject(fn url -> url == "#" end)
+      |> Enum.reject(fn %{title: title, url: url} ->
+        url == "#" || title == ""
+      end)
 
     %{
       search_result_urls: search_result_urls,


### PR DESCRIPTION
Closes #47

## What happened

The rejected clause in the search_result parser was not properly pattern matched and letting all invalid links to be counted.

## Insight

We have to properly pattern match and remove any blank links or blank titles that are being scraped.

## Proof Of Work

#### Properly counts how many titles exist 🎉 
![Screen Shot 2021-07-05 at 8 37 16 AM](https://user-images.githubusercontent.com/34730459/124406709-48a65980-dd6c-11eb-8524-9a675528d0ff.png)
![Screen Shot 2021-07-05 at 8 37 31 AM](https://user-images.githubusercontent.com/34730459/124406710-49d78680-dd6c-11eb-8f0e-481758a89bdb.png)

